### PR TITLE
Fix: Resolve dark mode border issue and remove dead space

### DIFF
--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -25,16 +25,25 @@
     }
 
     /* General Page Setup */
-    html, body {
-      width: 100%; /* Crucial for preventing horizontal overflow issues */
+    html {
+      width: 100%;
+      min-height: 100vh;
+      margin: 0;
+      padding: 0; /* Remove padding from html */
+      overflow-x: hidden; /* Apply to html to prevent scrollbars from body content */
+      /* position: relative; -- Not strictly necessary on html if body is used for positioning context */
+    }
+
+    body {
+      width: 100%;
+      min-height: 100vh;
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
       margin: 0;
-      padding: 10px; /* Base padding for the page content area. Reduced from 10px 20px. Adjusted in media queries. */
-      color: #fff; /* Default text color */
-      min-height: 100vh; /* Ensure body takes at least full viewport height */
-      background: linear-gradient(135deg, #1a2a6c, #b21f1f, #fdbb2d); /* Background gradient */
+      padding: 10px; /* Base padding for the page content area. Adjusted in media queries. */
+      color: #fff; /* Default text color for light mode */
+      background: linear-gradient(135deg, #1a2a6c, #b21f1f, #fdbb2d); /* Light mode background on BODY */
       position: relative; /* For positioning of absolute children like blobs/character */
-      overflow-x: hidden; /* Prevents horizontal scrollbars if any content accidentally overflows. Applied to html and body. */
+      /* overflow-x: hidden; -- Moved to HTML */
     }
 
     /* Decorative Animated Blobs (Background) */


### PR DESCRIPTION
This commit fixes an issue where a border of the light theme was visible around the page edges when dark mode was active. It also removes any 'dead space' outside the main body content area.

Changes in `styles/new-ui.css`:
- Modified the main page setup by splitting the `html, body` rule.
- The `html` element now has `padding: 0; margin: 0;` and no background explicitly set. It handles `overflow-x: hidden`.
- The `body` element now solely carries the theme-specific background (defaulting to light mode gradient, switching in dark mode). It retains its existing `padding` rules for content spacing, which now correctly applies inside the body's background area.

This ensures the `body` background (light or dark) extends to the full viewport edges, eliminating the unintended border effect in dark mode and ensuring no wasted space from `html` element styling.